### PR TITLE
only applying flexbox to blog

### DIFF
--- a/wp-content/themes/accelerate-theme/style.css
+++ b/wp-content/themes/accelerate-theme/style.css
@@ -670,7 +670,7 @@ a.button, a.button:link {
 	   transition: all 0.5s ease;
 	   background: #eeeeee;
    }
-.site-content {
+.blog .site-content {
 	   display: -webkit-box;
 	   display: -moz-box;
 	   display: -ms-flexbox;


### PR DESCRIPTION
After testing applying flexbox only to .site-content on the blog page should relieve some student headaches.